### PR TITLE
Fix fromMasterSeed argument type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
+import { Buffer } from "safe-buffer";
+
 declare module "ethereumjs-wallet" {
-  import { Buffer } from "safe-buffer";
 
   class Wallet {
     static fromPrivateKey(key: Buffer): Wallet;
@@ -20,5 +21,5 @@ declare module "ethereumjs-wallet/hdkey" {
     getWallet(): Wallet
   }
 
-  export function fromMasterSeed(seed: string): EthereumHDKey
+  export function fromMasterSeed(seed: Buffer): EthereumHDKey
 }


### PR DESCRIPTION
`fromMasterSeed` argument type should be `Buffer` please see [this](https://github.com/ethereumjs/ethereumjs-wallet/blob/master/hdkey.js#L17) and [this](https://github.com/cryptocoinjs/hdkey/blob/master/README.md#usage). Though using `string` type as input would work, in reality it would yield different addresses and can potentially be a security vulnerability.

Consider this snippet:

```
import { mnemonicToSeed } from 'bip39';
import { fromMasterSeed } from 'ethereumjs-wallet/hdkey';

const getHDWallet = (
  mnemonic: string
) => fromMasterSeed(mnemonicToSeed(mnemonic).toString()); // If we remove .toString() here we would get different address.

const getWalletHdPath = () => 'm/44\'/60\'/0\'/0/';

const deriveWallet = (hdWallet, walletHdpath) => hdWallet.derivePath(walletHdpath + 0).getWallet();

const getWallet = mnemonic => {
  const hdWallet = getHDWallet(mnemonic);
  const walletHdpath = getWalletHdPath();
  return deriveWallet(hdWallet, walletHdpath);
};
```